### PR TITLE
webpack等でimportする際にnpm名のみでimport可能にする

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "shitajicss",
   "description": "Resetting CSS for web production",
   "version": "4.3.0",
+  "main": "docs/css/shitaji.css",
   "style": "docs/css/shitaji.css",
   "keywords": [
     "css",


### PR DESCRIPTION
現状だと

```main.js
import 'shitajicss/docs/css/shitaji.min.css';
```

と記載が必要なため

```main.js
import 'shitajicss';
```

でimport可能になっているとありがたいです。